### PR TITLE
Fixed camera

### DIFF
--- a/foodplanner/lib/components/custom_square_camera_overlay.dart
+++ b/foodplanner/lib/components/custom_square_camera_overlay.dart
@@ -5,18 +5,19 @@ class CustomSquareCameraOverlay extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final paint = Paint()..color = Colors.black.withOpacity(0.5);
 
-    // Define the size, position, and corner radius of the rounded square cutout
-    final double squareSize = size.width * 0.95; // Adjust square size as needed
+    final double squareSize =
+        size.width < size.height ? size.width : size.height;
+
     final double left = (size.width - squareSize) / 2;
     final double top = (size.height - squareSize) / 2;
     final double right = left + squareSize;
     final double bottom = top + squareSize;
-    final double borderRadius = 20.0; // Adjust for desired roundness
+    final double borderRadius = 20.0;
 
-    // Draw the overlay with a transparent rounded square in the center
     final overlayPath = Path()
-      ..addRect(Rect.fromLTWH(0, 0, size.width, size.height)) // Full screen
-      ..addRRect(RRect.fromLTRBR(left, top, right, bottom, Radius.circular(borderRadius))) // Rounded cutout
+      ..addRect(Rect.fromLTWH(0, 0, size.width, size.height))
+      ..addRRect(RRect.fromLTRBR(left, top, right, bottom,
+          Radius.circular(borderRadius))) // Rounded cutout
       ..fillType = PathFillType.evenOdd; // Make the cutout transparent
 
     canvas.drawPath(overlayPath, paint);
@@ -24,6 +25,6 @@ class CustomSquareCameraOverlay extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    return false; // No need to repaint unless dimensions change
+    return false;
   }
 }

--- a/foodplanner/lib/pages/camera_page.dart
+++ b/foodplanner/lib/pages/camera_page.dart
@@ -9,6 +9,7 @@ import 'package:foodplanner/config/text_styles.dart';
 import 'package:http/http.dart';
 import 'package:image/image.dart' as img;
 import 'package:http_parser/http_parser.dart';
+import 'package:foodplanner/components/custom_square_camera_overlay.dart';
 
 import 'package:foodplanner/config/colors.dart';
 import 'package:image_picker/image_picker.dart';
@@ -97,7 +98,24 @@ class _MealPageState extends State<CameraPage> {
         future: _initializeControllerFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.done) {
-            return CameraPreview(_controller);
+            final size = MediaQuery.of(context).size;
+            final deviceRatio = size.width / size.height;
+
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                Center(
+                  child: AspectRatio(
+                    aspectRatio: _controller.value.aspectRatio,
+                    child: CameraPreview(_controller),
+                  ),
+                ),
+                CustomPaint(
+                  painter: CustomSquareCameraOverlay(),
+                  child: Container(),
+                ),
+              ],
+            );
           } else {
             return Center(child: CircularProgressIndicator());
           }


### PR DESCRIPTION
This fix makes it so that when viewing an image in the camera page itself, a cutout correctly shows what part of the image will be saved for the actual meal / ingredient