### PR TITLE
fix: show real user name on landing instead of "Unknown Unknown" (#212)

### DIFF
--- a/foodplanner/lib/services/user_service.dart
+++ b/foodplanner/lib/services/user_service.dart
@@ -9,6 +9,23 @@ class UserService {
 
   UserService({required this.apiUrl});
 
+  /// Normalises the `role` field, which some endpoints return as the backend
+  /// UserRole int bitflag (Admin=1, Child=2, Teacher=4, Parent=8) while the
+  /// frontend User model expects a role string ("admin"/"child"/"teacher"/"parent").
+  static String _roleString(dynamic role) {
+    if (role is String) return role;
+    if (role is int) {
+      return switch (role) {
+        1 => 'admin',
+        2 => 'child',
+        4 => 'teacher',
+        8 => 'parent',
+        _ => 'parent',
+      };
+    }
+    return 'parent';
+  }
+
   Future<User> fetchUser(int id) async {
     final jwtToken = await AuthProvider().retrieveToken();
     final response = await http.get(Uri.parse('$apiUrl/api/Admin/Get/$id'),
@@ -23,7 +40,7 @@ class UserService {
         'first_name': json['firstName'],
         'last_name': json['lastName'],
         'email': json['email'],
-        'role': json['role'],
+        'role': _roleString(json['role']),
         'archived': json['archived'],
       };
       return User.fromJson(filteredJson);
@@ -43,10 +60,10 @@ class UserService {
       final Map<String, dynamic> json = jsonDecode(response.body);
       final filteredJson = {
         'id': json['id'],
-        'first_name': json['first_name'],
-        'last_name': json['last_name'],
+        'first_name': json['firstName'],
+        'last_name': json['lastName'],
         'email': json['email'],
-        'role': json['role'],
+        'role': _roleString(json['role']),
         'archived': json['archived'],
       };
       return User.fromJson(filteredJson);
@@ -211,10 +228,10 @@ class UserService {
       final Map<String, dynamic> json = jsonDecode(response.body);
       final filteredJson = {
         'id': json['id'],
-        'first_name': json['first_name'],
-        'last_name': json['last_name'],
+        'first_name': json['firstName'],
+        'last_name': json['lastName'],
         'email': json['email'],
-        'role': json['role'],
+        'role': _roleString(json['role']),
         'archived': json['archived'],
       };
       return User.fromJson(filteredJson);


### PR DESCRIPTION
> 🤖 **AI-generated PR.** Written and verified by **Claude (Claude Code)** on behalf of @nbhansen. Please review before merging.

Fixes **#212**.

## Problem

After login, the teacher and guardian landing pages greet the user as **"Velkommen Unknown Unknown"** (or fall back to "Forældre"), even though the account has a name. `fetchLoggedInUser()` / `userInfo()` can't parse the `GET /api/Users/GetLoggedIn` response, so they fall back to the hard-coded `'Unknown'` user. There are **two** causes:

1. **camelCase keys** — they read `json['first_name']` / `json['last_name']`, but the API returns `firstName` / `lastName`. (The sibling `fetchUser()` already reads camelCase correctly.)
2. **role type** — `GetLoggedIn` returns `role` as the backend `UserRole` int bitflag (e.g. `4` for Teacher), but `User.fromJson` pattern-matches `'role': String role` and then calls `UserRoles.fromString(...)`, so an int throws a `FormatException`.

Fixing only (1) is not enough — (2) still throws. Both are needed.

## Fix

In `user_service.dart`:
- Read the camelCase `firstName` / `lastName` keys in `fetchLoggedInUser` and `userInfo`.
- Add a small `_roleString` helper that normalises `role` (accepts int **or** string: `1→admin, 2→child, 4→teacher, 8→parent`) and use it everywhere a `User` is built from an API response.

## Verification

Built `flutter build web` and logged in: the teacher landing now shows **"Velkommen Sofie Nielsen"** and the guardian landing shows **"Velkommen Mette"** (both previously "Unknown"/"Forældre").

## Alternative

This could also be addressed backend-side by serialising `role` as a string from `GetLoggedIn` (consistent with the role-claim string used elsewhere). The frontend change is the smaller, self-contained fix.